### PR TITLE
デザイン修整

### DIFF
--- a/foreground/css/popup.css
+++ b/foreground/css/popup.css
@@ -12,4 +12,9 @@ body{
   background-image: url("../img/logo-t.png");
   background-repeat: no-repeat; /* 繰り返し表示オフ */
   padding: 5px 0px 0px 40px;
+  margin-top: 10px;
+}
+
+.row{
+  margin-left: 0px;
 }


### PR DESCRIPTION
ロゴの上に空白を追加
ホスト名入力欄の左側空白を他のに揃える

変更前
![screenshot 2018-03-19 2](https://user-images.githubusercontent.com/3890567/37572719-a433359a-2b52-11e8-87a4-486ae4e15587.jpg)
変更後
![screenshot 2018-03-19 1](https://user-images.githubusercontent.com/3890567/37572722-abf3d488-2b52-11e8-8398-e18b02aaffac.jpg)


